### PR TITLE
remove A1/A2 <-> M1/M2 channel aliasing

### DIFF
--- a/src/standards.jl
+++ b/src/standards.jl
@@ -66,7 +66,7 @@ const STANDARD_LABELS = Dict(# This EEG channel name list is a combined 10/20 an
                                         :af7, :af3, :afz, :af4, :af8,
                                         :f9, :f7, :f5, :f3, :f1, :fz, :f2, :f4, :f6, :f8, :f10,
                                         :ft9, :ft7, :fc5, :fc3, :fc1, :fcz, :fc2, :fc4, :fc6, :ft8, :ft10,
-                                        :a1 => [:m1], :t9, :t7, :t3, :c5, :c3, :c1, :cz, :c2, :c4, :c6, :t4, :t8, :t10, :a2 => [:m2],
+                                        :a1, :m1, :t9, :t7, :t3, :c5, :c3, :c1, :cz, :c2, :c4, :c6, :t4, :t8, :t10, :a2, :m2,
                                         :tp9, :tp7, :cp5, :cp3, :cp1, :cpz, :cp2, :cp4, :cp6, :tp8, :tp10,
                                         :t5, :p9, :p7, :p5, :p3, :p1, :pz, :p2, :p4, :p6, :p8, :p10, :t6,
                                         :po7, :po3, :poz, :po4, :po8,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using OndaEDF, Onda, EDF
 @testset "EDF.Signal label handling" begin
     signal_names = [:eeg, :test]
     canonical_names = OndaEDF.STANDARD_LABELS[[:eeg]]
-    @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", signal_names, :c3, canonical_names) == Symbol("c3-a1_plus_a2_over_2")
+    @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", signal_names, :c3, canonical_names) == Symbol("c3-m1_plus_a2_over_2")
     @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", [:ecg], :c3, canonical_names) == nothing
     @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", signal_names, :c4, canonical_names) == nothing
     @test OndaEDF.match_edf_label(" TEsT   -Fpz  -REF-cpz", signal_names, :fpz, canonical_names) == Symbol("-fpz-ref-cpz")
@@ -115,8 +115,8 @@ returned_uuid, recording = import_edf!(dataset, edf, uuid)
     @test recording.signals[:emg].sample_unit == :microvolt
     @test recording.signals[:eog].channel_names == [:left, :right]
     @test recording.signals[:eog].sample_unit == :microvolt
-    @test recording.signals[:eeg].channel_names == [:fpz, Symbol("f3-a2"), Symbol("f4-a1"), Symbol("c3-a2"),
-                                                    Symbol("c4-a1"), Symbol("o1-a2"), Symbol("o2-a1")]
+    @test recording.signals[:eeg].channel_names == [:fpz, Symbol("f3-m2"), Symbol("f4-m1"), Symbol("c3-m2"),
+                                                    Symbol("c4-m1"), Symbol("o1-m2"), Symbol("o2-a1")]
     @test recording.signals[:eeg].sample_unit == :microvolt
     @test recording.signals[:pap_device_cflow].channel_names == [:pap_device_cflow]
     @test recording.signals[:pap_device_cflow].sample_unit == :liter_per_minute


### PR DESCRIPTION
It turns out that these are not the same, though they are similarly used as references. 

From @ararslan: "M1/2 are the mastoids and A1/2 are earlobes."