### PR TITLE
Document and lightly refactor signal extraction during import

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDF"
 uuid = "e3ed2cd1-99bf-415e-bb8f-38f4b42a544e"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,8 +21,17 @@ edf_to_onda_samples
 edf_to_onda_annotations
 ```
 
+### Import utilities
+
+```@docs
+extract_channels_by_label
+edf_signals_to_samplesinfo
+```
+
+### Full-service import
+
 For a more "full-service" experience, OndaEDF.jl also provides functionality to
-write the extracted signals/annotations to disk:
+extract `Onda.Samples` and `Onda.Annotations` and then write them to disk:
 
 ```@docs
 store_edf_as_onda

--- a/src/OndaEDF.jl
+++ b/src/OndaEDF.jl
@@ -11,8 +11,9 @@ include("standards.jl")
 
 include("import_edf.jl")
 export edf_to_onda_samples, edf_to_onda_annotations, store_edf_as_onda
+export extract_channels_by_label, edf_signals_to_samplesinfo
 
 include("export_edf.jl")
-export onda_to_edf
+export onda_to_edf 
 
 end # module

--- a/src/OndaEDF.jl
+++ b/src/OndaEDF.jl
@@ -14,6 +14,6 @@ export edf_to_onda_samples, edf_to_onda_annotations, store_edf_as_onda
 export extract_channels_by_label, edf_signals_to_samplesinfo
 
 include("export_edf.jl")
-export onda_to_edf 
+export onda_to_edf
 
 end # module

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -204,7 +204,7 @@ can be either a `String` giving the generated channel name, or a `Pair` mapping
 a canonical name to a list of alternatives that it should be substituted for
 (e.g., `"canonical_name" => ["alt1", "alt2", ...]`).
 
-See OndaEDF.STANDARD_LABELS for the labels (`signal_names => channel_names`
+See `OndaEDF.STANDARD_LABELS` for the labels (`signal_names => channel_names`
 `Pair`s) that are used to extract EDF signals by default.
 
 """

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -163,7 +163,7 @@ function extract_channels(edf_signals, channel_matchers)
 end
 
 """
-    edf_signals_to_samplesinfo(edf_signals, kind, channel_names)
+    edf_signals_to_samplesinfo(edf, edf_signals, kind, channel_names, samples_per_record)
 
 Generate a single `Onda.SamplesInfo` for the given a collection of `EDF.Signal`s
 corresponding to multiple channels from a single signal kind.  Sample units are
@@ -172,7 +172,7 @@ converted to Onda units and checked for consistency, and a promoted encoding
 
 No conversion of the actual signals is performed at this step.
 """
-function edf_signals_to_samplesinfo(edf_signals, kind, channel_names)
+function edf_signals_to_samplesinfo(edf::EDF.File, edf_signals::Vector{<:EDF.Signal}, kind, channel_names)
     onda_units = map(s -> edf_to_onda_unit(s.header.physical_dimension), edf_signals)
     onda_sample_unit = first(onda_units)
     all(==(onda_sample_unit), onda_units) || error("multiple possible units found for same signal: $onda_units")
@@ -218,7 +218,7 @@ function extract_channels_by_label(edf::EDF.File, signal_names, channel_names)
     edf_channel_names, edf_channels = extract_channels(edf.signals, (matcher(x) for x in channel_names))
     isempty(edf_channel_names) && return nothing
 
-    info = edf_signals_to_samplesinfo(edf_channels, first(signals_names), edf_channel_names)
+    info = edf_signals_to_samplesinfo(edf, edf_channels, first(signal_names), edf_channel_names)
     return info, edf_channels
 end
 

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -166,7 +166,7 @@ end
     edf_signals_to_samplesinfo(edf, edf_signals, kind, channel_names, samples_per_record)
 
 Generate a single `Onda.SamplesInfo` for the given collection of `EDF.Signal`s
-corresponding to multiple channels from a single signal kind.  Sample units are
+corresponding to the channels of a single Onda signal.  Sample units are
 converted to Onda units and checked for consistency, and a promoted encoding
 (resolution, offset, and sample type/rate) is generated.
 

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -165,7 +165,7 @@ end
 """
     edf_signals_to_samplesinfo(edf, edf_signals, kind, channel_names, samples_per_record)
 
-Generate a single `Onda.SamplesInfo` for the given a collection of `EDF.Signal`s
+Generate a single `Onda.SamplesInfo` for the given collection of `EDF.Signal`s
 corresponding to multiple channels from a single signal kind.  Sample units are
 converted to Onda units and checked for consistency, and a promoted encoding
 (resolution, offset, and sample type/rate) is generated.

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -279,9 +279,12 @@ Collections of `EDF.Signal`s are mapped as channels to `Onda.Signal`s via simple
     edf::EDF.File -> (samples_info::Onda.SamplesInfo,
                       edf_signals::Vector{EDF.Signal})
 
-`store_edf_as_onda` automatically uses a variety of default extractors derived from
-the EDF standard texts; see `src/standards.jl` for details. The caller can also
-provide additional extractors via the `custom_extractors` keyword argument.
+`store_edf_as_onda` automatically uses a variety of default extractors derived
+from the EDF standard texts; see `src/standards.jl` and
+[`extract_channels_by_label`](@ref) for details. The caller can also provide
+additional extractors via the `custom_extractors` keyword argument, and the
+[`edf_signals_to_samplesinfo`](@ref) utility can be used to extract a common
+`Onda.SamplesInfo` from a collection of EDF.Signals.
 
 `EDF.Signal` labels that are converted into Onda channel names undergo the
 following transformations:


### PR DESCRIPTION
This documents and refactors some internal functions to make it slightly easier
to create custom extractor functions.  The main change is that the construction
of the `Onda.SamplesInfo` from a collection of `EDF.Signal`s is extracted into
its own function, since that's likely to be needed by custom extractors that
can't rely on the labels.  Additionally, this adds docstrings for
`extract_channels_by_label` and the new `edf_signals_to_samplesinfo` functions.

It does not export them or include them in the docs, although that may be the
right way to go if they're now meant to be used to create custom extractors.