### PR TITLE
Return file paths from `store_edf_as_onda`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Beacon Biosignals, Inc."]
 version = "0.9.1"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 EDF = "ccffbfc1-f56e-50fb-a33b-53d1781b2825"
 Onda = "e853f5be-6863-11e9-128d-476edb89bfb5"
@@ -13,6 +14,7 @@ TimeSpans = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
+Compat = "3.32"
 EDF = "0.6"
 Onda = "0.12, 0.13, 0.14"
 StatsBase = "0.33"

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 Compat = "3.32"
 EDF = "0.6"
+FilePathsBase = "0.9"
 Onda = "0.12, 0.13, 0.14"
 StatsBase = "0.33"
 Tables = "1.4"
@@ -23,9 +24,10 @@ TimeSpans = "0.2"
 julia = "1.4"
 
 [extras]
+FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Statistics"]
+test = ["FilePathsBase", "Test", "Random", "Statistics"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDF"
 uuid = "e3ed2cd1-99bf-415e-bb8f-38f4b42a544e"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/OndaEDF.jl
+++ b/src/OndaEDF.jl
@@ -1,6 +1,7 @@
 module OndaEDF
 
 using Base.Iterators
+using Compat: @compat
 using Dates, UUIDs
 using Onda, EDF
 using StatsBase

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -386,8 +386,8 @@ function store_edf_as_onda(edf::EDF.File, onda_dir, recording_uuid::UUID=uuid4()
     for samples in edf_samples
         sample_filename = string(recording_uuid, "_", samples.info.kind, ".", file_format)
         file_path = joinpath(onda_dir, "samples", sample_filename)
-        signal = rowmerge(store(file_path, file_format, samples, recording_uuid, Second(0)); file_path=string(file_path))
-        push!(signals, Onda.Signal(signal))
+        signal = store(file_path, file_format, samples, recording_uuid, Second(0))
+        push!(signals, signal)
     end
 
     write_signals(signals_path, signals)
@@ -412,6 +412,7 @@ function store_edf_as_onda(path, edf::EDF.File, uuid::UUID=uuid4(); kwargs...)
                  "instead.",
                  :store_edf_as_onda)
     nt = store_edf_as_onda(edf, path, uuid; kwargs...)
+    signals = [rowmerge(s; file_path=string(s.file_path)) for s in nt.signals]
     return nt.recording_uuid => (nt.signals, nt.annotations)
 end
 

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -403,7 +403,7 @@ function store_edf_as_onda(edf::EDF.File, onda_dir, recording_uuid::UUID=uuid4()
         annotations = Onda.Annotation[]
     end
 
-    return (; recording_uuid, signals, annotations, signals_path, annotations_path)
+    return @compat (; recording_uuid, signals, annotations, signals_path, annotations_path)
 end
 
 function store_edf_as_onda(path, edf::EDF.File, uuid::UUID=uuid4(); kwargs...)

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -387,7 +387,7 @@ function store_edf_as_onda(edf::EDF.File, onda_dir, recording_uuid::UUID=uuid4()
         sample_filename = string(recording_uuid, "_", samples.info.kind, ".", file_format)
         file_path = joinpath(onda_dir, "samples", sample_filename)
         signal = rowmerge(store(file_path, file_format, samples, recording_uuid, Second(0)); file_path=string(file_path))
-        push!(signals, signal)
+        push!(signals, Onda.Signal(signal))
     end
 
     write_signals(signals_path, signals)

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -377,6 +377,8 @@ function store_edf_as_onda(edf::EDF.File, onda_dir, recording_uuid::UUID=uuid4()
     EDF.read!(edf)
     file_format = "lpcm.zst"
 
+    mkpath(joinpath(onda_dir, "samples"))
+
     signals = Onda.Signal[]
     edf_samples, diagnostics = edf_to_onda_samples(edf; custom_extractors=custom_extractors)
     for e in diagnostics.errors

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -402,7 +402,7 @@ end
 
 function validate_arrow_prefix(prefix)
     prefix == basename(prefix) || throw(ArgumentError("prefix \"$prefix\" is invalid: cannot contain directory separator"))
-    pm = match(r"(.*).onda.(signals|annotations).arrow", prefix)
+    pm = match(r"(.*)\.onda\.(signals|annotations)\.arrow", prefix)
     if pm !== nothing
         @warn "Extracting prefix \"$(pm.captures[1])\" from provided prefix \"$prefix\""
         prefix = pm.captures[1]

--- a/test/export.jl
+++ b/test/export.jl
@@ -86,29 +86,29 @@
 
     @testset "full service" begin
         # import annotations
-        recordings, round_tripped = store_edf_as_onda(mktempdir(), exported_edf, uuid).second
-        @test round_tripped isa Vector{<:Onda.Annotation}
+        nt = store_edf_as_onda(exported_edf, mktempdir(), uuid)
+        @test nt.annotations isa Vector{<:Onda.Annotation}
         # annotations are sorted by start time on export
         ann_sorted = sort(annotations; by=row -> Onda.start(row.span))
-        @test getproperty.(round_tripped, :span) == getproperty.(ann_sorted, :span)
-        @test getproperty.(round_tripped, :value) == getproperty.(ann_sorted, :value)
+        @test getproperty.(nt.annotations, :span) == getproperty.(ann_sorted, :span)
+        @test getproperty.(nt.annotations, :value) == getproperty.(ann_sorted, :value)
         # same recording UUID passed as original:
-        @test getproperty.(round_tripped, :recording) == getproperty.(ann_sorted, :recording)
+        @test getproperty.(nt.annotations, :recording) == getproperty.(ann_sorted, :recording)
         # new UUID for each annotation created during import
-        @test all(getproperty.(round_tripped, :id) .!= getproperty.(ann_sorted, :id))
+        @test all(getproperty.(nt.annotations, :id) .!= getproperty.(ann_sorted, :id))
         info_orig = first(onda_samples).info
-        info_round_tripped = SamplesInfo(first(recordings))
+        info_round_tripped = SamplesInfo(first(nt.signals))
                     
         @test all(getproperty(info_orig, p) == getproperty(info_round_tripped, p) for p in propertynames(info_orig))
 
         # don't import annotations
-        recordings, round_tripped = store_edf_as_onda(mktempdir(), exported_edf, uuid; import_annotations=false).second
-        @test round_tripped isa Vector{<:Onda.Annotation}
-        @test length(round_tripped) == 0
+        nt = store_edf_as_onda(exported_edf, mktempdir(), uuid; import_annotations=false)
+        @test nt.annotations isa Vector{<:Onda.Annotation}
+        @test length(nt.annotations) == 0
 
         # import empty annotations
         exported_edf2 = onda_to_edf(samples_to_export)
-        @test_logs (:warn, r"No annotations found in") store_edf_as_onda(mktempdir(), exported_edf2, uuid; import_annotations=true)
+        @test_logs (:warn, r"No annotations found in") store_edf_as_onda(exported_edf2, mktempdir(), uuid; import_annotations=true)
     end
 
 end

--- a/test/import.jl
+++ b/test/import.jl
@@ -428,7 +428,20 @@ end
             mktempdir() do root
                 @test_throws ArgumentError OndaEDF.store_edf_as_onda(edf, root, uuid; signals_prefix="stuff/edf", annotations_prefix="edf")
             end
-            
+        end
+
+        @testset "AbstractPath support" begin
+            mktempdir() do dir
+                root = PosixPath(dir)
+                nt = OndaEDF.store_edf_as_onda(edf, root, uuid)
+
+                @test nt.signals_path isa AbstractPath
+                @test isfile(nt.signals_path)
+                @test nt.annotations_path isa AbstractPath
+                @test isfile(nt.annotations_path)
+                @test isdir(joinpath(dirname(nt.signals_path), "samples"))
+                @test all(p -> p isa AbstractPath, (s.file_path for s in nt.signals))
+            end
         end
     end
 

--- a/test/import.jl
+++ b/test/import.jl
@@ -367,17 +367,17 @@ end
         end
 
         @testset "Annotations import" begin
-            @test length(annotations) == n_records * 4
+            @test length(nt.annotations) == n_records * 4
             # check whether all four types of annotations are preserved on import:
             for i in 1:n_records
                 start = Nanosecond(Second(i))
                 stop = start + Nanosecond(Second(i + 1))
                 # two annotations with same 1s span and different values:
-                @test any(a -> a.value == "$i a" && a.span.start == start && a.span.stop == stop, annotations)
-                @test any(a -> a.value == "$i b" && a.span.start == start && a.span.stop == stop, annotations)
+                @test any(a -> a.value == "$i a" && a.span.start == start && a.span.stop == stop, nt.annotations)
+                @test any(a -> a.value == "$i b" && a.span.start == start && a.span.stop == stop, nt.annotations)
                 # two annotations with instantaneous (1ns) span and different values
-                @test any(a -> a.value == "$i c" && a.span.start == start && a.span.stop == start + Nanosecond(1), annotations)
-                @test any(a -> a.value == "$i d" && a.span.start == start && a.span.stop == start + Nanosecond(1), annotations)
+                @test any(a -> a.value == "$i c" && a.span.start == start && a.span.stop == start + Nanosecond(1), nt.annotations)
+                @test any(a -> a.value == "$i d" && a.span.start == start && a.span.stop == start + Nanosecond(1), nt.annotations)
             end
         end
 

--- a/test/import.jl
+++ b/test/import.jl
@@ -314,14 +314,16 @@ end
     @testset "store_edf_as_onda" begin
         root = mktempdir()
         uuid = uuid4()
-        returned_uuid, (returned_signals, annotations) = OndaEDF.store_edf_as_onda(root, edf, uuid)
-        signals = Dict(s.kind => s for s in returned_signals)
+        nt = OndaEDF.store_edf_as_onda(edf, root, uuid)
+        signals = Dict(s.kind => s for s in nt.signals)
 
-        @test isfile(joinpath(root, "edf.onda.signals.arrow"))
-        @test isfile(joinpath(root, "edf.onda.annotations.arrow"))
+        @test nt.signals_path == joinpath(root, "edf.onda.signals.arrow")
+        @test nt.annotations_path == joinpath(root, "edf.onda.annotations.arrow")
+        @test isfile(nt.signals_path)
+        @test isfile(nt.annotations_path)
 
-        @test returned_uuid == uuid
-        @test length(returned_signals) == 13
+        @test nt.recording_uuid == uuid
+        @test length(nt.signals) == 13
         @testset "samples info" begin
             @test signals["tidal_volume"].channels == ["tidal_volume"]
             @test signals["tidal_volume"].sample_unit == "milliliter"
@@ -392,37 +394,39 @@ end
             @test prefix == "edf"
 
             mktempdir() do root
-                OndaEDF.store_edf_as_onda(root, edf, uuid; signals_prefix="edfff")
-                @test isfile(joinpath(root, "edfff.onda.signals.arrow"))
-                @test isfile(joinpath(root, "edfff.onda.annotations.arrow"))
+                nt = OndaEDF.store_edf_as_onda(edf, root, uuid; signals_prefix="edfff")
+                @test nt.signals_path == joinpath(root, "edfff.onda.signals.arrow")
+                @test nt.annotations_path == joinpath(root, "edfff.onda.annotations.arrow")
             end
 
             mktempdir() do root
-                OndaEDF.store_edf_as_onda(root, edf, uuid; annotations_prefix="edff")
-                @test isfile(joinpath(root, "edf.onda.signals.arrow"))
-                @test isfile(joinpath(root, "edff.onda.annotations.arrow"))
+                nt = OndaEDF.store_edf_as_onda(edf, root, uuid; annotations_prefix="edff")
+                @test nt.signals_path == joinpath(root, "edf.onda.signals.arrow")
+                @test nt.annotations_path == joinpath(root, "edff.onda.annotations.arrow")
             end
 
             mktempdir() do root
-                OndaEDF.store_edf_as_onda(root, edf, uuid; annotations_prefix="edff")
-                @test isfile(joinpath(root, "edf.onda.signals.arrow"))
-                @test isfile(joinpath(root, "edff.onda.annotations.arrow"))
+                nt = OndaEDF.store_edf_as_onda(edf, root, uuid; annotations_prefix="edff")
+                @test nt.signals_path == joinpath(root, "edf.onda.signals.arrow")
+                @test nt.annotations_path == joinpath(root, "edff.onda.annotations.arrow")
             end
 
             mktempdir() do root
-                OndaEDF.store_edf_as_onda(root, edf, uuid; signals_prefix="edfff", annotations_prefix="edff")
-                @test isfile(joinpath(root, "edfff.onda.signals.arrow"))
-                @test isfile(joinpath(root, "edff.onda.annotations.arrow"))
+                nt = OndaEDF.store_edf_as_onda(edf, root, uuid; signals_prefix="edfff", annotations_prefix="edff")
+                @test nt.signals_path == joinpath(root, "edfff.onda.signals.arrow")
+                @test nt.annotations_path == joinpath(root, "edff.onda.annotations.arrow")
             end
 
             mktempdir() do root
-                @test_logs (:warn, r"Extracting prefix") OndaEDF.store_edf_as_onda(root, edf, uuid; signals_prefix="edff.onda.signals.arrow", annotations_prefix="edf")
-                @test isfile(joinpath(root, "edff.onda.signals.arrow"))
-                @test isfile(joinpath(root, "edf.onda.annotations.arrow"))
+                @test_logs (:warn, r"Extracting prefix") begin
+                    nt = OndaEDF.store_edf_as_onda(edf, root, uuid; signals_prefix="edff.onda.signals.arrow", annotations_prefix="edf")
+                end
+                @test nt.signals_path == joinpath(root, "edff.onda.signals.arrow")
+                @test nt.annotations_path == joinpath(root, "edf.onda.annotations.arrow")
             end
 
             mktempdir() do root
-                @test_throws ArgumentError OndaEDF.store_edf_as_onda(root, edf, uuid; signals_prefix="stuff/edf", annotations_prefix="edf")
+                @test_throws ArgumentError OndaEDF.store_edf_as_onda(edf, root, uuid; signals_prefix="stuff/edf", annotations_prefix="edf")
             end
             
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test, Dates, Random, UUIDs, Statistics
 using OndaEDF, Onda, EDF, Tables
+using FilePathsBase: AbstractPath, PosixPath
 
 function test_edf_signal(rng, label, transducer, physical_units,
                          physical_min, physical_max,


### PR DESCRIPTION
The `store_edf_as_onda` function has been updated to return a `NamedTuple` which includes the paths to the signals and annotations files. The original method has been deprecated. The reason a deprecation was possible at all here was because the input arguments for `store_edf_as_onda` also needed to be changed to be in the order "source then destination".

Fixes:
- https://github.com/beacon-biosignals/OndaEDF.jl/issues/30

Blocked by:
- https://github.com/beacon-biosignals/Legolas.jl/pull/26
- ~https://github.com/beacon-biosignals/Legolas.jl/pull/27~
