### PR TITLE
Update docs for `onda_to_edf` to accurately reflect input

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDF"
 uuid = "e3ed2cd1-99bf-415e-bb8f-38f4b42a544e"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/export_edf.jl
+++ b/src/export_edf.jl
@@ -132,22 +132,23 @@ end
 #####
 
 """
-    onda_to_edf(signals, annotations=[]; kwargs...)
+    onda_to_edf(samples::AbstractVector{<:Samples}, annotations=[]; kwargs...)
 
-Return an `EDF.File` containing signal data converted from the Onda [`signals`
-table](https://beacon-biosignals.github.io/Onda.jl/stable/#*.onda.signals.arrow-1)
-and (optionally) annotations from an [`annotations`
+Return an `EDF.File` containing signal data converted from a collection of Onda
+[`Samples`](https://beacon-biosignals.github.io/Onda.jl/stable/#Samples-1) and
+(optionally) annotations from an [`annotations`
 table](https://beacon-biosignals.github.io/Onda.jl/stable/#*.onda.annotations.arrow-1).
 
-Following the Onda v0.5 format, both `signals` and `annotations` can be any
-Tables.jl-compatible table (DataFrame, Arrow.Table, NamedTuple of vectors, vector of
-NamedTuples) which follow the signal and annotation schemas (respectively).
+Following the Onda v0.5 format, `annotations` can be any Tables.jl-compatible
+table (DataFrame, Arrow.Table, NamedTuple of vectors, vector of NamedTuples)
+which follow the annotation schema (respectively).
 
-Each `EDF.Signal` in the returned `EDF.File` corresponds to a channel of an `Onda.Signal`.
+Each `EDF.Signal` in the returned `EDF.File` corresponds to a channel of an
+input `Onda.Samples`.
 
-The ordering of `EDF.Signal`s in the output will match the order of the rows of
-the signals table (and within each channel grouping, the order of the signal's
-channels).
+The ordering of `EDF.Signal`s in the output will match the order of the input
+collection of `Samples` (and within each channel grouping, the order of the
+samples' channels).
 """
 function onda_to_edf(samples::AbstractVector{<:Samples}, annotations=[]; kwargs...)
     edf_header = onda_samples_to_edf_header(samples; kwargs...)

--- a/src/export_edf.jl
+++ b/src/export_edf.jl
@@ -141,7 +141,8 @@ table](https://beacon-biosignals.github.io/Onda.jl/stable/#*.onda.annotations.ar
 
 Following the Onda v0.5 format, `annotations` can be any Tables.jl-compatible
 table (DataFrame, Arrow.Table, NamedTuple of vectors, vector of NamedTuples)
-which follow the annotation schema (respectively).
+which follows the [annotation
+schema](https://beacon-biosignals.github.io/Onda.jl/stable/#*.onda.annotations.arrow-1).
 
 Each `EDF.Signal` in the returned `EDF.File` corresponds to a channel of an
 input `Onda.Samples`.


### PR DESCRIPTION
The current docstring for `onda_to_edf` refers to a signals table as output, but
the function actually takes an `AbstractVector` of `Samples` instead of a
signals table.  This updates the docstring to reflect this.