### PR TITLE
Ignore `-org` as an EDF channel name suffix

### DIFF
--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -51,7 +51,7 @@ function _normalize_references(original_label, canonical_names)
         label = only(m.captures)
     end
     parts = split(label, '…'; keepempty=false)
-    final = findlast(part -> replace(part, r"\d" => "") != "ref", parts)
+    final = findlast(part -> !(replace(part, r"\d" => "") in ("ref", "org")), parts)
     parts = parts[1:something(final, 0)]
     isempty(parts) && return ("", "")
     for n in canonical_names

--- a/test/signal_labels.jl
+++ b/test/signal_labels.jl
@@ -1,6 +1,7 @@
 @testset "EDF.Signal label handling" begin
     signal_names = ["eeg", "eog", "test"]
     canonical_names = OndaEDF.STANDARD_LABELS[["eeg"]]
+    @test OndaEDF.match_edf_label("EEG C3-Org", signal_names, "c3", canonical_names) == "c3"
     @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", signal_names, "c3", canonical_names) == "c3-m1_plus_a2_over_2"
     @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", ["ecg"], "c3", canonical_names) == nothing
     @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", signal_names, "c4", canonical_names) == nothing


### PR DESCRIPTION
I've encountered this quite a bit lately. It does not appear to be particularly meaningful in the same way that e.g. the `-ref` suffix isn't. No one is certain what exactly it means but the best guess is an abbreviation of "original" for "original reference."