### PR TITLE
Fix typo/extra space with the `etco2` channel name

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDF"
 uuid = "e3ed2cd1-99bf-415e-bb8f-38f4b42a544e"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.10.2"
+version = "0.10.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/standards.jl
+++ b/src/standards.jl
@@ -99,4 +99,4 @@ const STANDARD_LABELS = Dict(# This EEG channel name list is a combined 10/20 an
                              ["tidal_volume"] => ["tidal_volume"=> ["tvol", "tidal"]],
                              ["spo2"] => ["spo2"],
                              ["sao2"] => ["sao2", "osat"],
-                             ["etco2"] => ["etco2 "=> ["capno"]])
+                             ["etco2"] => ["etco2"=> ["capno"]])

--- a/src/standards.jl
+++ b/src/standards.jl
@@ -99,4 +99,4 @@ const STANDARD_LABELS = Dict(# This EEG channel name list is a combined 10/20 an
                              ["tidal_volume"] => ["tidal_volume"=> ["tvol", "tidal"]],
                              ["spo2"] => ["spo2"],
                              ["sao2"] => ["sao2", "osat"],
-                             ["etco2"] => ["etco2"=> ["capno"]])
+                             ["etco2"] => ["etco2" => ["capno"]])


### PR DESCRIPTION
Otherwise the channel name "etco2 " will hit the invalid channel name error at:
https://github.com/beacon-biosignals/Onda.jl/blob/6952dd2b59fd16c02f0a80b96ca7c2f627b04ca0/src/signals.jl#L136

Credit to @mich11 for finding this problem in the source code!