### PR TITLE
add `recording` as optional field to OndaEDF.PlanV[12]

### DIFF
--- a/OndaEDFSchemas.jl/Project.toml
+++ b/OndaEDFSchemas.jl/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDFSchemas"
 uuid = "9c87d999-769b-4741-85b2-6f554d09e731"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Legolas = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"

--- a/OndaEDFSchemas.jl/Project.toml
+++ b/OndaEDFSchemas.jl/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.2"
 [deps]
 Legolas = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 Onda = "e853f5be-6863-11e9-128d-476edb89bfb5"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Legolas = "0.5.5"

--- a/OndaEDFSchemas.jl/src/OndaEDFSchemas.jl
+++ b/OndaEDFSchemas.jl/src/OndaEDFSchemas.jl
@@ -23,7 +23,8 @@ export PlanV1, PlanV2, FilePlanV1, FilePlanV2, EDFAnnotationV1
     samples_per_record::Int16
     # EDF.FileHeader field
     seconds_per_record::Float64
-    # Onda.SamplesInfoV1 fields (channels -> channel), may be missing
+    # Onda.SignalV1 fields (channels -> channel), may be missing
+    recording::Union{UUID,Missing} = lift(UUID, recording)
     kind::Union{Missing,AbstractString} = lift(String, kind)
     channel::Union{Missing,AbstractString} = lift(String, channel)
     sample_unit::Union{Missing,AbstractString} = lift(String, sample_unit)
@@ -48,7 +49,8 @@ end
     samples_per_record::Int16
     # EDF.FileHeader field
     seconds_per_record::Float64
-    # Onda.SamplesInfoV2 fields (channels -> channel), may be missing
+    # Onda.SignalV2 fields (channels -> channel), may be missing
+    recording::Union{UUID,Missing} = lift(UUID, recording)
     sensor_type::Union{Missing,AbstractString} = lift(_validate_signal_sensor_type, sensor_type)
     sensor_label::Union{Missing,AbstractString} = lift(_validate_signal_sensor_label,
                                                        coalesce(sensor_label, sensor_type))
@@ -78,7 +80,8 @@ const PLAN_DOC_TEMPLATE = """
         samples_per_record::Int16
         # EDF.FileHeader field
         seconds_per_record::Float64
-        # Onda.SamplesInfo fields (channels -> channel), may be missing
+        # Onda.SignalV{{ VERSION }} fields (channels -> channel), may be missing
+        recording::Union{UUID,Missing} = passmissing(UUID)
 {{ SAMPLES_INFO_UNIQUE_FIELDS }}
         channel::Union{Missing,AbstractString}
         sample_unit::Union{Missing,AbstractString}
@@ -94,8 +97,8 @@ A Legolas-generated record type describing a single EDF signal-to-Onda channel
 conversion.  The columns are the union of
 - fields from `EDF.SignalHeader` (all mandatory)
 - the `seconds_per_record` field from `EDF.FileHeader` (mandatory)
-- fields from `Onda.SamplesInfoV{{ VERSION }}` (optional, may be `missing` to indicate failed
-  conversion)
+- fields from `Onda.SignalV{{ VERSION }}` (optional, may be `missing` to indicate failed
+  conversion), except for `file_path`
 - `error`, which is `nothing` for a conversion that is or is expected to be
   successful, and a `String` describing the source of the error (with backtrace)
   in the case of a caught error.

--- a/OndaEDFSchemas.jl/src/OndaEDFSchemas.jl
+++ b/OndaEDFSchemas.jl/src/OndaEDFSchemas.jl
@@ -5,6 +5,7 @@ using Onda: LPCM_SAMPLE_TYPE_UNION, onda_sample_type_from_julia_type,
             convert_number_to_lpcm_sample_type, _validate_signal_channel,
             _validate_signal_sensor_label, _validate_signal_sensor_type,
             AnnotationV1
+using UUIDs
 
 export PlanV1, PlanV2, FilePlanV1, FilePlanV2, EDFAnnotationV1
 

--- a/OndaEDFSchemas.jl/test/runtests.jl
+++ b/OndaEDFSchemas.jl/test/runtests.jl
@@ -44,7 +44,7 @@ function mock_plan(; v, rng=GLOBAL_RNG)
                        sample_type=ingested ? "float32" : missing,
                        sample_rate=ingested ? 1/128 : missing,
                        error=errored ? "Error blah blah" : nothing,
-                       recording= (ingested && rand(rng, Bool)) ? uuid4() : missing
+                       recording= (ingested && rand(rng, Bool)) ? uuid4() : missing,
                        specific_kwargs...)
 end
 

--- a/OndaEDFSchemas.jl/test/runtests.jl
+++ b/OndaEDFSchemas.jl/test/runtests.jl
@@ -26,6 +26,7 @@ function mock_plan(; v, rng=GLOBAL_RNG)
         error("Invalid version")
     end
     errored = !ingested && rand(rng, Bool)
+    recording = 
     PlanVersion = v == 1 ? PlanV1 : PlanV2
     return PlanVersion(; label="EEG CZ-M1",
                        transducer_type="Ag-Cl electrode",
@@ -44,6 +45,7 @@ function mock_plan(; v, rng=GLOBAL_RNG)
                        sample_type=ingested ? "float32" : missing,
                        sample_rate=ingested ? 1/128 : missing,
                        error=errored ? "Error blah blah" : nothing,
+                       recording= (ingested && rand(rng, Bool)) ? uuid4() : missing
                        specific_kwargs...)
 end
 

--- a/OndaEDFSchemas.jl/test/runtests.jl
+++ b/OndaEDFSchemas.jl/test/runtests.jl
@@ -26,7 +26,6 @@ function mock_plan(; v, rng=GLOBAL_RNG)
         error("Invalid version")
     end
     errored = !ingested && rand(rng, Bool)
-    recording = 
     PlanVersion = v == 1 ? PlanV1 : PlanV2
     return PlanVersion(; label="EEG CZ-M1",
                        transducer_type="Ag-Cl electrode",

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDF"
 uuid = "e3ed2cd1-99bf-415e-bb8f-38f4b42a544e"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -218,7 +218,14 @@ is thrown.  If sample rates/offests are not equal, then `pick_offset` and
     This is an internal function and is not meant to be called direclty.
 """
 function promote_encodings(encodings; pick_offset=(_ -> 0.0), pick_resolution=minimum)
-    if any(any(ismissing, row) for row in encodings)
+    encoding_fields = (:sample_rate,
+                       :sample_offset_in_unit,
+                       :sample_resolution_in_unit,
+                       :sample_type)
+    if any(ismissing,
+           getproperty(row, p)
+           for p in encoding_fields
+           for row in encodings)
         return (; sample_type=missing,
                 sample_offset_in_unit=missing,
                 sample_resolution_in_unit=missing,


### PR DESCRIPTION
We've been previously working around this by adding `recording` as a "silent schema extension" in existing plan tables, but with Legolas 0.5 this would require specifying an explicit extension and I don't see a downside to making it an optional field in these schemas.  I opted to put it in teh `Plan` schema (rather than `FilePlan`) because I couldn't think of a good reason not to (the only difference between them is that the FilePlan has the EDF signal-to-Onda Samples index mappings)

Given that this schema evolution doesn't invalidate previously valid tables, I've left the schema versions alone.

This change also turned up an issue with how `promote_encodings` was checking for missing values in the plan row: if _any_ value was missing it assumed that the corresponding signal was not matched and bombed out.  Since this introduces a (possibly missing) `recording` field in the plan schema, it was always failing.  So I restricted the check in `promote_encodings` to only check whether one of the four relevant fields is missing.  This is a bugfix IMO.