### PR TITLE
allow `_` to separate signal and sensor spec in labels

### DIFF
--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -146,7 +146,7 @@ function match_edf_label(label, signal_names, channel_name, canonical_names)
     # - if the signal name itself contains whitespace or one of `",[]"`, it
     #   will not match.  the fix for this is to preprocess signal headers before
     #   `plan_edf_to_onda_samples` to normalize known instances (after reviewing the plan)
-    m = match(r"[\s\[,\]]*(?<signal>.+?)[\s,\]]*\s+(?<spec>.+)"i, label)
+    m = match(r"[\s\[,\]]*(?<signal>.+?)[\s,\]]*[\s_]+(?<spec>.+)"i, label)
     if !isnothing(m) && m[:signal] in signal_names
         label = m[:spec]
     end

--- a/test/signal_labels.jl
+++ b/test/signal_labels.jl
@@ -2,7 +2,6 @@
     signal_names = ["eeg", "eog", "test"]
     canonical_names = OndaEDF.STANDARD_LABELS[["eeg"]]
     @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", signal_names, "c3", canonical_names) == "c3-m1_plus_a2_over_2"
-    @test OndaEDF.match_edf_label("EEG_C3-(M1 +A2)/2 - rEf3", signal_names, "c3", canonical_names) == "c3-m1_plus_a2_over_2"
     @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", ["ecg"], "c3", canonical_names) == nothing
     @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", signal_names, "c4", canonical_names) == nothing
     @test OndaEDF.match_edf_label(" TEsT   -Fpz  -REF-cpz", signal_names, "fpz", canonical_names) == "-fpz-ref-cpz"
@@ -17,6 +16,8 @@
             @test name == "avr" ? x == "avr" : x == nothing
         end
     end
+    # #70
+    @test OndaEDF.match_edf_label("EEG_C3-A2", signal_names, "c3", canonical_names) == "c3-a2"
     @test OndaEDF.export_edf_label("eeg", "t4") == "EEG T4-Ref"
     @test OndaEDF.export_edf_label("eeg", "t4-a1") == "EEG T4-A1"
     @test OndaEDF.export_edf_label("emg", "lat") == "EMG LAT"

--- a/test/signal_labels.jl
+++ b/test/signal_labels.jl
@@ -2,6 +2,7 @@
     signal_names = ["eeg", "eog", "test"]
     canonical_names = OndaEDF.STANDARD_LABELS[["eeg"]]
     @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", signal_names, "c3", canonical_names) == "c3-m1_plus_a2_over_2"
+    @test OndaEDF.match_edf_label("EEG_C3-(M1 +A2)/2 - rEf3", signal_names, "c3", canonical_names) == "c3-m1_plus_a2_over_2"
     @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", ["ecg"], "c3", canonical_names) == nothing
     @test OndaEDF.match_edf_label("EEG C3-(M1 +A2)/2 - rEf3", signal_names, "c4", canonical_names) == nothing
     @test OndaEDF.match_edf_label(" TEsT   -Fpz  -REF-cpz", signal_names, "fpz", canonical_names) == "-fpz-ref-cpz"


### PR DESCRIPTION
This is one possible fix to #70 .  I'm honestly not sure if this is a good idea or not; on the one hand, it does allow us to handle things like `"EEG_C3-A2"`, but on the other hand, the EDF+ spec is fairly clear that the signal/sensor separator should be a single space.  HOWEVER, we allow all kinds of other crap in there besides just a single space so I'm not _too_ bothered by deviating from that slightly.

The alternative would be to require users pre-process the `label` field into something spec-compliant enough to be matched with `OndaEDF.match_edf_label`.