### PR TITLE
bump statsbase compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDF"
 uuid = "e3ed2cd1-99bf-415e-bb8f-38f4b42a544e"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.11.5"
+version = "0.11.6"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -25,7 +25,7 @@ Onda = "0.15"
 OndaEDFSchemas = "0.2.1"
 PrettyTables = "1.3, 2"
 StableRNGs = "1"
-StatsBase = "0.33"
+StatsBase = "0.33, 0.34"
 Tables = "1.4"
 TimeSpans = "0.3"
 julia = "1.6"


### PR DESCRIPTION
Previous versions did not compat bound statsbase which leads to an ancient version of OndaEDF being installed when StatsBase 0.34 is installed.