### PR TITLE
match units, labels, and encoding independently while planning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDF"
 uuid = "e3ed2cd1-99bf-415e-bb8f-38f4b42a544e"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.11.6"
+version = "0.11.7"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -360,6 +360,12 @@ function plan_edf_to_onda_samples(header,
     row = (; header..., seconds_per_record, error=nothing)
 
     try
+        # match physical units first so that we give users better feedback about
+        # _which_ thing (labels vs. units) didn't match.
+        #
+        # still do it in the try/catch in case edf_to_onda_unit throws an error
+        row = rowmerge(row; sample_unit=edf_to_onda_unit(header.physical_dimension, units))
+
         edf_label = header.label
         for (signal_names, channel_names) in labels
             # channel names is iterable of channel specs, which are either "channel"
@@ -375,7 +381,6 @@ function plan_edf_to_onda_samples(header,
                                    channel=matched,
                                    sensor_type=first(signal_names),
                                    sensor_label=first(signal_names),
-                                   sample_unit=edf_to_onda_unit(header.physical_dimension, units),
                                    edf_signal_encoding(header, seconds_per_record)...)
                     return PlanV2(row)
                 end

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -363,7 +363,8 @@ function plan_edf_to_onda_samples(header,
         # match physical units and encoding first so that we give users better
         # feedback about _which_ thing (labels vs. units) didn't match.
         #
-        # still do it in the try/catch in case edf_to_onda_unit throws an error
+        # still do it in the try/catch in case edf_to_onda_unit or
+        # edf_signal_encoding throws an error
         row = rowmerge(row;
                        sample_unit=edf_to_onda_unit(header.physical_dimension, units),
                        edf_signal_encoding(header, seconds_per_record)...)

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -360,11 +360,13 @@ function plan_edf_to_onda_samples(header,
     row = (; header..., seconds_per_record, error=nothing)
 
     try
-        # match physical units first so that we give users better feedback about
-        # _which_ thing (labels vs. units) didn't match.
+        # match physical units and encoding first so that we give users better
+        # feedback about _which_ thing (labels vs. units) didn't match.
         #
         # still do it in the try/catch in case edf_to_onda_unit throws an error
-        row = rowmerge(row; sample_unit=edf_to_onda_unit(header.physical_dimension, units))
+        row = rowmerge(row;
+                       sample_unit=edf_to_onda_unit(header.physical_dimension, units),
+                       edf_signal_encoding(header, seconds_per_record)...)
 
         edf_label = header.label
         for (signal_names, channel_names) in labels
@@ -380,8 +382,7 @@ function plan_edf_to_onda_samples(header,
                     row = rowmerge(row; 
                                    channel=matched,
                                    sensor_type=first(signal_names),
-                                   sensor_label=first(signal_names),
-                                   edf_signal_encoding(header, seconds_per_record)...)
+                                   sensor_label=first(signal_names))
                     return PlanV2(row)
                 end
             end


### PR DESCRIPTION
A common issue that users experience is that when _either_ labels or units fail to match, _everything_ is set to missing (including the encoding parameters).  This makes it difficult to tell what the source of the failure to match is, and also makes it functionally impossible to do a manual "clean up" edit of the plan after the fact.

This PR hoists the unit and encoding matching out of the loop that matches labels.

Fixes #69 