### PR TITLE
fix docs build on tags without explicitly adding OndaEDFSchemas

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDF"
 uuid = "e3ed2cd1-99bf-415e-bb8f-38f4b42a544e"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.11.8"
+version = "0.11.9"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,7 @@
 using OndaEDF
-using OndaEDFSchemas
 using Documenter
 
-makedocs(modules=[OndaEDF, OndaEDFSchemas],
+makedocs(modules=[OndaEDF, OndaEDF.OndaEDFSchemas],
          sitename="OndaEDF",
          authors="Beacon Biosignals and other contributors",
          pages=["OndaEDF" => "index.md",


### PR DESCRIPTION
The documenter build is failing on tags but not on the other builds.  I think this is because the other builds, we explicitly `dev` the local version of OndaEDFSchemas, but on tags we don't.  This PR fixes the docs build by using `OndaEDF.OndaEDFSchemas` instead of `OndaEDFSchema` directly.