### PR TITLE
fix handling of negative resolutions in export

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDF"
 uuid = "e3ed2cd1-99bf-415e-bb8f-38f4b42a544e"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/export_edf.jl
+++ b/src/export_edf.jl
@@ -135,7 +135,7 @@ function reencode_samples(samples::Samples, sample_type::Type{<:Integer}=Int16)
                                              samples.info.sample_offset_in_unit,
                                              (smin, smax))
             # make sure we handle negative resolutions properly!
-            # smin, smax = extrema((smin, smax))
+            smin, smax = extrema((smin, smax))
         end
         if smin >= typemin(sample_type) && smax <= typemax(sample_type)
             # XXX: we're being a bit clever here in order to not allocate a

--- a/src/export_edf.jl
+++ b/src/export_edf.jl
@@ -134,6 +134,8 @@ function reencode_samples(samples::Samples, sample_type::Type{<:Integer}=Int16)
                                              samples.info.sample_resolution_in_unit,
                                              samples.info.sample_offset_in_unit,
                                              (smin, smax))
+            # make sure we handle negative resolutions properly!
+            # smin, smax = extrema((smin, smax))
         end
         if smin >= typemin(sample_type) && smax <= typemax(sample_type)
             # XXX: we're being a bit clever here in order to not allocate a


### PR DESCRIPTION
fixes #80 

issue was with an optimized path (not re-encoding if the encoded values can be directly converted to Int16 losslessly) was not handling negative resolution correctly for decoded samples as input.  one line fix and added more tests (confirmed to fail on this case before the fix was pushed, see the first build).