### PR TITLE
drop misleading bit of docstring

### DIFF
--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -503,9 +503,6 @@ rows with the same `:onda_signal_index` into a common `Onda.SamplesInfo`.  Then
 [`OndaEDF.onda_samples_from_edf_signals`](@ref) is used to combine the EDF
 signals data into a single `Onda.Samples` per group.
 
-The `label` of the original `EDF.Signal`s are preserved in the `:edf_channels`
-field of the resulting `SamplesInfo`s for each `Samples` generated.
-
 Any errors that occur are shown as `String`s (with backtrace) and inserted into
 the `:error` column for the corresponding rows from the plan.
 


### PR DESCRIPTION
related to https://github.com/beacon-biosignals/OndaEDF.jl/issues/86

I think we should leave that issue open to track the missing feature (unless we aren't going to provide it), but in the meantime it's better to not include this bit of the docstring since it isn't true.