### PR TITLE
handle edge case in `reencode_samples`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDF"
 uuid = "e3ed2cd1-99bf-415e-bb8f-38f4b42a544e"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.12.2"
+version = "0.12.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/export_edf.jl
+++ b/src/export_edf.jl
@@ -155,6 +155,11 @@ function reencode_samples(samples::Samples, sample_type::Type{<:Integer}=Int16)
     # maximize the dynamic range of Int16 encoding.
     samples = decode(samples)
     smin, smax = extrema(samples.data)
+    # If the input is flat, normalize to zero and one
+    if smin == smax
+        smax = one(smax)
+        smin = zero(smin)
+    end
 
     emin, emax = typemin(sample_type), typemax(sample_type)
 

--- a/src/export_edf.jl
+++ b/src/export_edf.jl
@@ -155,7 +155,7 @@ function reencode_samples(samples::Samples, sample_type::Type{<:Integer}=Int16)
     # maximize the dynamic range of Int16 encoding.
     samples = decode(samples)
     smin, smax = extrema(samples.data)
-    # If the input is flat, normalize to zero and one
+    # If the input is flat, normalize max to min + 1
     if smin == smax
         smax = smin + one(smax)
     end

--- a/src/export_edf.jl
+++ b/src/export_edf.jl
@@ -157,8 +157,7 @@ function reencode_samples(samples::Samples, sample_type::Type{<:Integer}=Int16)
     smin, smax = extrema(samples.data)
     # If the input is flat, normalize to zero and one
     if smin == smax
-        smax = one(smax)
-        smin = zero(smin)
+        smax = smin + one(smax)
     end
 
     emin, emax = typemin(sample_type), typemax(sample_type)

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -194,6 +194,10 @@ function edf_signal_encoding(edf_signal_header, edf_seconds_per_record)
     dmin, dmax = edf_signal_header.digital_minimum, edf_signal_header.digital_maximum
     pmin, pmax = edf_signal_header.physical_minimum, edf_signal_header.physical_maximum
     sample_resolution_in_unit = (pmax - pmin) / (dmax - dmin)
+    if !isfinite(sample_resolution_in_unit) || iszero(sample_resolution_in_unit)
+        @warn "Unexpected computed `sample_resolution_in_unit`. Computed: $(sample_resolution_in_unit). Setting to 1." digital_minimum=dmin digital_maximum=dmax physical_minimum=pmin physical_maximum=pmax maxlog=10
+        sample_resolution_in_unit = one(sample_resolution_in_unit)
+    end
     sample_offset_in_unit = pmin - (sample_resolution_in_unit * dmin)
     sample_rate = edf_signal_header.samples_per_record / edf_seconds_per_record
     sample_type = (dmax > typemax(Int16) || dmin < typemin(Int16)) ? "int32" : "int16"

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -194,10 +194,6 @@ function edf_signal_encoding(edf_signal_header, edf_seconds_per_record)
     dmin, dmax = edf_signal_header.digital_minimum, edf_signal_header.digital_maximum
     pmin, pmax = edf_signal_header.physical_minimum, edf_signal_header.physical_maximum
     sample_resolution_in_unit = (pmax - pmin) / (dmax - dmin)
-    if !isfinite(sample_resolution_in_unit) || iszero(sample_resolution_in_unit)
-        @warn "Unexpected computed `sample_resolution_in_unit`. Computed: $(sample_resolution_in_unit). Setting to 1." digital_minimum=dmin digital_maximum=dmax physical_minimum=pmin physical_maximum=pmax maxlog=10
-        sample_resolution_in_unit = one(sample_resolution_in_unit)
-    end
     sample_offset_in_unit = pmin - (sample_resolution_in_unit * dmin)
     sample_rate = edf_signal_header.samples_per_record / edf_seconds_per_record
     sample_type = (dmax > typemax(Int16) || dmin < typemin(Int16)) ? "int32" : "int16"

--- a/test/export.jl
+++ b/test/export.jl
@@ -258,9 +258,11 @@
             sample_type=Float64,
             sample_rate=1)
 
-        data = zeros(UInt64, 1, 2)
+        data = zeros(UInt64, 1, 2) .+ 0x02
         samples = Samples(data, info, false)
-        @test OndaEDF.reencode_samples(samples) isa Samples
+        samples_reenc = OndaEDF.reencode_samples(samples)
+        @test samples_reenc isa Samples
+        @test decode(samples_reenc).data == data
     end
     
 end

--- a/test/export.jl
+++ b/test/export.jl
@@ -8,8 +8,8 @@
     annotations = edf_to_onda_annotations(edf, uuid)
 
     signal_names = ["eeg", "eog", "ecg", "emg", "heart_rate", "tidal_volume",
-        "respiratory_effort", "snore", "positive_airway_pressure",
-        "pap_device_leak", "pap_device_cflow", "sao2", "ptaf"]
+                    "respiratory_effort", "snore", "positive_airway_pressure",
+                    "pap_device_leak", "pap_device_cflow", "sao2", "ptaf"]
     samples_to_export = onda_samples[indexin(signal_names, getproperty.(getproperty.(onda_samples, :info), :sensor_type))]
     exported_edf = onda_to_edf(samples_to_export, annotations)
     @test exported_edf.header.record_count == 200
@@ -61,7 +61,7 @@
 
         @testset "Exception and Error handling" begin
             messages = ("RecordSizeException: sample rates [9999.0, 425.0] cannot be resolved to a data record size smaller than 61440 bytes",
-                "EDFPrecisionError: String representation of value 2.0576999e7 is longer than 8 ASCII characters")
+                        "EDFPrecisionError: String representation of value 2.0576999e7 is longer than 8 ASCII characters")
             exceptions = (OndaEDF.RecordSizeException([chunky_eeg, chunky_ecg]), OndaEDF.EDFPrecisionError(20576999.0))
             for (message, exception) in zip(messages, exceptions)
                 buffer = IOBuffer()
@@ -108,7 +108,7 @@
 
             samples_rt = Onda.load(signal_round_tripped)
             @test all(isapprox.(decode(samples_orig).data, decode(samples_rt).data;
-                atol=info_orig.sample_resolution_in_unit))
+                                atol=info_orig.sample_resolution_in_unit))
         end
 
         # don't import annotations
@@ -135,12 +135,12 @@
         # possible Onda sample type.
         @testset "encoding $T, resolution $res" for T in onda_types, res in (-0.2, 0.2)
             info = SamplesInfoV2(; sensor_type="x",
-                channels=["x"],
-                sample_unit="microvolt",
-                sample_resolution_in_unit=res,
-                sample_offset_in_unit=1,
-                sample_type=T,
-                sample_rate=1)
+                                 channels=["x"],
+                                 sample_unit="microvolt",
+                                 sample_resolution_in_unit=res,
+                                 sample_offset_in_unit=1,
+                                 sample_type=T,
+                                 sample_rate=1)
 
             if T <: AbstractFloat
                 min = nextfloat(typemin(T))
@@ -178,12 +178,12 @@
 
         @testset "skip reencoding (res = $res)" for res in (-2, 2)
             info = SamplesInfoV2(; sensor_type="x",
-                channels=["x"],
-                sample_unit="microvolt",
-                sample_resolution_in_unit=res,
-                sample_offset_in_unit=1,
-                sample_type=Int32,
-                sample_rate=1)
+                                 channels=["x"],
+                                 sample_unit="microvolt",
+                                 sample_resolution_in_unit=res,
+                                 sample_offset_in_unit=1,
+                                 sample_type=Int32,
+                                 sample_rate=1)
 
             data = Int32[typemin(Int16) typemax(Int16)]
 
@@ -263,5 +263,5 @@
         result = (@test_logs (:warn, r"Unexpected computed `sample_resolution_in_unit`.") OndaEDF.reencode_samples(samples))
         @test result isa Samples
     end
-
+    
 end

--- a/test/export.jl
+++ b/test/export.jl
@@ -8,8 +8,8 @@
     annotations = edf_to_onda_annotations(edf, uuid)
 
     signal_names = ["eeg", "eog", "ecg", "emg", "heart_rate", "tidal_volume",
-                    "respiratory_effort", "snore", "positive_airway_pressure",
-                    "pap_device_leak", "pap_device_cflow", "sao2", "ptaf"]
+        "respiratory_effort", "snore", "positive_airway_pressure",
+        "pap_device_leak", "pap_device_cflow", "sao2", "ptaf"]
     samples_to_export = onda_samples[indexin(signal_names, getproperty.(getproperty.(onda_samples, :info), :sensor_type))]
     exported_edf = onda_to_edf(samples_to_export, annotations)
     @test exported_edf.header.record_count == 200
@@ -61,7 +61,7 @@
 
         @testset "Exception and Error handling" begin
             messages = ("RecordSizeException: sample rates [9999.0, 425.0] cannot be resolved to a data record size smaller than 61440 bytes",
-                        "EDFPrecisionError: String representation of value 2.0576999e7 is longer than 8 ASCII characters")
+                "EDFPrecisionError: String representation of value 2.0576999e7 is longer than 8 ASCII characters")
             exceptions = (OndaEDF.RecordSizeException([chunky_eeg, chunky_ecg]), OndaEDF.EDFPrecisionError(20576999.0))
             for (message, exception) in zip(messages, exceptions)
                 buffer = IOBuffer()
@@ -108,7 +108,7 @@
 
             samples_rt = Onda.load(signal_round_tripped)
             @test all(isapprox.(decode(samples_orig).data, decode(samples_rt).data;
-                                atol=info_orig.sample_resolution_in_unit))
+                atol=info_orig.sample_resolution_in_unit))
         end
 
         # don't import annotations
@@ -135,12 +135,12 @@
         # possible Onda sample type.
         @testset "encoding $T, resolution $res" for T in onda_types, res in (-0.2, 0.2)
             info = SamplesInfoV2(; sensor_type="x",
-                                 channels=["x"],
-                                 sample_unit="microvolt",
-                                 sample_resolution_in_unit=res,
-                                 sample_offset_in_unit=1,
-                                 sample_type=T,
-                                 sample_rate=1)
+                channels=["x"],
+                sample_unit="microvolt",
+                sample_resolution_in_unit=res,
+                sample_offset_in_unit=1,
+                sample_type=T,
+                sample_rate=1)
 
             if T <: AbstractFloat
                 min = nextfloat(typemin(T))
@@ -178,12 +178,12 @@
 
         @testset "skip reencoding (res = $res)" for res in (-2, 2)
             info = SamplesInfoV2(; sensor_type="x",
-                                 channels=["x"],
-                                 sample_unit="microvolt",
-                                 sample_resolution_in_unit=res,
-                                 sample_offset_in_unit=1,
-                                 sample_type=Int32,
-                                 sample_rate=1)
+                channels=["x"],
+                sample_unit="microvolt",
+                sample_resolution_in_unit=res,
+                sample_offset_in_unit=1,
+                sample_type=Int32,
+                sample_rate=1)
 
             data = Int32[typemin(Int16) typemax(Int16)]
 
@@ -246,6 +246,22 @@
             signal = only(OndaEDF.onda_samples_to_edf_signals([samples], 1.0))
             @test EDF.decode(signal) == vec(decode(samples).data)
         end
+    end
+
+    @testset "`reencode_samples` edge case" begin
+        # Weird encoding
+        info = SamplesInfoV2(; sensor_type="x",
+            channels=["x"],
+            sample_unit="microvolt",
+            sample_resolution_in_unit=0.001,
+            sample_offset_in_unit=0,
+            sample_type=Float64,
+            sample_rate=1)
+
+        data = zeros(UInt64, 1, 2)
+        samples = Samples(data, info, false)
+        result = (@test_logs (:warn, r"Unexpected computed `sample_resolution_in_unit`.") OndaEDF.reencode_samples(samples))
+        @test result isa Samples
     end
 
 end

--- a/test/export.jl
+++ b/test/export.jl
@@ -260,8 +260,7 @@
 
         data = zeros(UInt64, 1, 2)
         samples = Samples(data, info, false)
-        result = (@test_logs (:warn, r"Unexpected computed `sample_resolution_in_unit`.") OndaEDF.reencode_samples(samples))
-        @test result isa Samples
+        @test OndaEDF.reencode_samples(samples) isa Samples
     end
     
 end

--- a/test/export.jl
+++ b/test/export.jl
@@ -248,7 +248,7 @@
         end
     end
 
-    @testset "`reencode_samples` edge case" begin
+    @testset "`reencode_samples` edge case: constant data" begin
         # Weird encoding
         info = SamplesInfoV2(; sensor_type="x",
             channels=["x"],


### PR DESCRIPTION
Encountered during testing in a closed-source repo.

Without this fix, we get
```julia
  Test threw exception
  Expression: OndaEDF.reencode_samples(samples) isa Samples
  InexactError: trunc(Int16, NaN)
  Stacktrace:
    [1] trunc
      @ ./float.jl:872 [inlined]
    [2] round
      @ ./float.jl:384 [inlined]
    [3] encode_sample
      @ ~/.julia/packages/Onda/7mYcu/src/samples.jl:192 [inlined]
    [4] encode_sample
      @ ~/.julia/packages/Onda/7mYcu/src/samples.jl:189 [inlined]
    [5] _broadcast_getindex_evalf
      @ ./broadcast.jl:683 [inlined]
    [6] _broadcast_getindex
      @ ./broadcast.jl:666 [inlined]
    [7] getindex
      @ ./broadcast.jl:610 [inlined]
    [8] macro expansion
      @ ./broadcast.jl:974 [inlined]
    [9] macro expansion
      @ ./simdloop.jl:77 [inlined]
   [10] copyto!
      @ ./broadcast.jl:973 [inlined]
   [11] copyto!
      @ ./broadcast.jl:926 [inlined]
   [12] materialize!(#unused#::Base.Broadcast.DefaultArrayStyle{2}, dest::Matrix{Int16}, bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{2}, Nothing, typeof(Onda.encode_sample), Tuple{Base.RefValue{Type{Int16}}, Float64, Float64, Matrix{UInt64}}})
      @ Base.Broadcast ./broadcast.jl:884
   [13] materialize!
      @ ./broadcast.jl:881 [inlined]
   [14] broadcast!(::typeof(Onda.encode_sample), ::Matrix{Int16}, ::Type, ::Float64, ::Float64, ::Matrix{UInt64})
      @ Base.Broadcast ./broadcast.jl:850
   [15] encode!
      @ ~/.julia/packages/Onda/7mYcu/src/samples.jl:290 [inlined]
   [16] encode(::Type{Int16}, sample_resolution_in_unit::Float64, sample_offset_in_unit::Float64, sample_data::Matrix{UInt64}, dither_storage::Nothing)
      @ Onda ~/.julia/packages/Onda/7mYcu/src/samples.jl:252
   [17] encode(samples::Samples{Matrix{UInt64}}, dither_storage::Nothing)
      @ Onda ~/.julia/packages/Onda/7mYcu/src/samples.jl:322
   [18] encode
      @ ~/.julia/packages/Onda/7mYcu/src/samples.jl:321 [inlined]
   [19] reencode_samples(samples::Samples{Matrix{UInt64}}, sample_type::Type{Int16})
      @ OndaEDF ~/OndaEDF.jl/src/export_edf.jl:178
   [20] reencode_samples(samples::Samples{Matrix{UInt64}})
      @ OndaEDF ~/OndaEDF.jl/src/export_edf.jl:123
   [21] top-level scope
      @ ~/.julia/juliaup/julia-1.9.3+0.aarch64.apple.darwin14/share/julia/stdlib/v1.9/Test/src/Test.jl:478
   [22] eval
      @ ./boot.jl:370 [inlined]
   [23] eval_user_input(ast::Any, backend::REPL.REPLBackend, mod::Module)
      @ REPL ~/.julia/juliaup/julia-1.9.3+0.aarch64.apple.darwin14/share/julia/stdlib/v1.9/REPL/src/REPL.jl:153
   [24] repl_backend_loop(backend::REPL.REPLBackend, get_module::Function)
      @ REPL ~/.julia/juliaup/julia-1.9.3+0.aarch64.apple.darwin14/share/julia/stdlib/v1.9/REPL/src/REPL.jl:249
   [25] start_repl_backend(backend::REPL.REPLBackend, consumer::Any; get_module::Function)
      @ REPL ~/.julia/juliaup/julia-1.9.3+0.aarch64.apple.darwin14/share/julia/stdlib/v1.9/REPL/src/REPL.jl:234
   [26] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool, backend::Any)
      @ REPL ~/.julia/juliaup/julia-1.9.3+0.aarch64.apple.darwin14/share/julia/stdlib/v1.9/REPL/src/REPL.jl:379
   [27] run_repl(repl::REPL.AbstractREPL, consumer::Any)
      @ REPL ~/.julia/juliaup/julia-1.9.3+0.aarch64.apple.darwin14/share/julia/stdlib/v1.9/REPL/src/REPL.jl:365
   [28] (::Base.var"#1017#1019"{Bool, Bool, Bool})(REPL::Module)
      @ Base ./client.jl:421
   [29] #invokelatest#2
      @ ./essentials.jl:819 [inlined]
   [30] invokelatest
      @ ./essentials.jl:816 [inlined]
   [31] run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
      @ Base ./client.jl:405
   [32] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:322
   [33] _start()
      @ Base ./client.jl:522
```
