### PR TITLE
Warn when generating samples if any duplicate sensor_types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaEDF"
 uuid = "e3ed2cd1-99bf-415e-bb8f-38f4b42a544e"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.13.1"
+version = "0.13.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -568,7 +568,7 @@ function edf_to_onda_samples(edf::EDF.File, plan_table; validate=true, dither_st
     exec = Tables.columntable(exec_rows)
 
     # warn if any of the samples have any duplicate sensor_types
-    samples_types = [samples.info.sensor_type for exec in skipmissing(exec.samples)]
+    samples_types = [samples.info.sensor_type for samples in skipmissing(exec.samples)]
     let
         dups = []
         seen = Set{String}()

--- a/src/import_edf.jl
+++ b/src/import_edf.jl
@@ -570,7 +570,7 @@ function edf_to_onda_samples(edf::EDF.File, plan_table; validate=true, dither_st
     # warn if any of the samples have any duplicate sensor_types
     samples_types = [samples.info.sensor_type for samples in skipmissing(exec.samples)]
     let
-        dups = []
+        dups = Set{String}()
         seen = Set{String}()
         for t in samples_types
             if t in seen
@@ -579,11 +579,11 @@ function edf_to_onda_samples(edf::EDF.File, plan_table; validate=true, dither_st
                 push!(seen, t)
             end
         end
+        isempty(dups) ||
+            @warn "Generated samples with duplicate `sensor_type`s:\n\n" *
+            "$(join(dups, ", ", " and ")).\n\n" *
+            "Be sure to create unique `sensor_label`s before storing!"
     end
-    isempty(dups) ||
-        @warn "Generated samples with duplicate `sensor_type`s: " *
-        "$(join(dups, ", ", " and ")).  " *
-        "Be sure to create unique `sensor_label`s before storing!"
 
     exec_plan = reduce(vcat, exec.plan_rows)
 

--- a/test/import.jl
+++ b/test/import.jl
@@ -40,7 +40,8 @@
             # one channel per signal, group by label
             grouped_plans = plan_edf_to_onda_samples_groups(signal_plans,
                                                             onda_signal_groupby=:label)
-            returned_samples, plan = edf_to_onda_samples(edf, grouped_plans)
+            # logs a warning at this stage because of Samples w/ duplicate sensor_types
+            returned_samples, plan = @test_logs (:warn, ) edf_to_onda_samples(edf, grouped_plans)
             @test all(==(1), channel_count.(returned_samples))
         end
 


### PR DESCRIPTION
This adds a warning when `edf_to_onda_samples` generates samples with duplicate
`sensor_type`s, with a pointer on how to resolve (generate unique `sensor_label`
when storing the samples).

I've also expanded the documentation section on how to handle storing Onda.Samples
to call out this specific issue (as well as more general issues like `start` being
relative to the recording).